### PR TITLE
Check length of string after formatting it

### DIFF
--- a/IRC-Relay/Program.cs
+++ b/IRC-Relay/Program.cs
@@ -100,7 +100,7 @@ namespace IRCRelay
             }
 
             // Send IRC Message
-            if (messageParam.Content.Length > 1000)
+            if (formatted.Length > 1000)
             {
                 await messageParam.Channel.SendMessageAsync("Error: messages > 1000 characters cannot be sent!");
                 return;


### PR DESCRIPTION
Instead of checking the length of the string that was received from discord. Large blocks of code will not get sent to irc when they should have been sent as hastebin link. This hopefully fixes it.