### PR TITLE
Adjust Config Class

### DIFF
--- a/IRC-Relay/Helpers.cs
+++ b/IRC-Relay/Helpers.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
-using Discord;
 using Discord.WebSocket;
-using Meebey.SmartIrc4net;
-using System.Collections;
-
 
 namespace IRCRelay
 {
@@ -97,6 +93,7 @@ namespace IRCRelay
         {
             foreach (SocketGuild guild in Program.Instance.client.Guilds) // loop through each discord guild
             {
+                
                 if (guild.Name.ToLower().Contains(targetGuild.ToLower())) // find target 
                 {
                     SocketTextChannel channel = FindChannel(guild, targetChannel); // find desired channel

--- a/IRC-Relay/Settings.cs
+++ b/IRC-Relay/Settings.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
 using System.Xml.Serialization;
 
-namespace IRCRelay.Config
+namespace IRCRelay.Settings
 {
 	public class Config
 	{
@@ -27,19 +27,15 @@ namespace IRCRelay.Config
 		[XmlIgnore]
 		public const string FileName = "Settings.xml";
 
-		// Globally accessable instance of loaded configuration.
-		[XmlIgnore]
-		public static Config Instance { get; private set; }
-
 		// Empty constructor for XmlSerializer.
 		public Config()
 		{
 		}
 
 		// Used to load the default configuration if Load() fails.
-		public static void Default()
+		public static Config CreateDefaultConfig()
         {
-            Config.Instance = new Config()
+            Config config = new Config()
             {
                 IRCServer = "server",
                 IRCPort = "port",
@@ -54,24 +50,26 @@ namespace IRCRelay.Config
                 DiscordGuildName = "server name",
                 DiscordChannelName = "text channel"
             };
+
+            return config;
         }
 
         // Loads the configuration from file.
-        public static void Load()
+        public static Config Load()
 		{
 			var serializer = new XmlSerializer(typeof(Config));
 
 			using (var fStream = new FileStream(Config.FileName, FileMode.Open))
-				Config.Instance = (Config)serializer.Deserialize(fStream);
+				 return (Config)serializer.Deserialize(fStream);
 		}
 
 		// Saves the configuration to file.
-		public void Save()
+		public static void Save(Config config)
 		{
 			var serializer = new XmlSerializer(typeof(Config));
 
 			using (var fStream = new FileStream(Config.FileName, FileMode.Create))
-				serializer.Serialize(fStream, this);
+				serializer.Serialize(fStream, config);
 		}
 	}
 }


### PR DESCRIPTION
Config class had a public static global var to access the information,
so that was removed in favor for a private var inside of the Program
class. This is a better encapsulation practice and is much cleaner.